### PR TITLE
Check that renderer has a '__portlet_metadata__' attribute

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,8 +5,9 @@ Changelog
 2.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Check that renderer has a '__portlet_metadata__' attribute
+  and compute 'assignment context' only for 'context' portlet.
+  [sverbois]
 
 2.0.3 (2014-10-13)
 ------------------
@@ -101,7 +102,7 @@ Changelog
 - Specify package dependencies.
   [hannosch]
 
-- Added 'tile' CSS class to the links within dt.portletHeader and 
+- Added 'tile' CSS class to the links within dt.portletHeader and
   dd.portletFooter for static portlet's template
   [spliter]
 

--- a/plone/portlet/static/static.py
+++ b/plone/portlet/static/static.py
@@ -133,10 +133,14 @@ class Renderer(base.Renderer):
         orig = orig.encode('utf-8')
 
         transformer = getToolByName(context, 'portal_transforms')
-        assignment_context_path = self.__portlet_metadata__['key']
-        assignment_context = context.restrictedTraverse(assignment_context_path)
+        transformer_context = context
+        if hasattr(self, '__portlet_metadata__'):
+            if self.__portlet_metadata__['category'] == 'context':
+                assignment_context_path = self.__portlet_metadata__['key']
+                assignment_context = context.unrestrictedTraverse(assignment_context_path)
+                transformer_context = assignment_context
         data = transformer.convertTo(mt, orig,
-                                     context=assignment_context, mimetype='text/html')
+                                     context=transformer_context, mimetype='text/html')
         result = data.getData()
         if result:
             if isinstance(result, str):

--- a/plone/portlet/static/tests/test_portlet_static.py
+++ b/plone/portlet/static/tests/test_portlet_static.py
@@ -69,9 +69,7 @@ class TestRenderer(TestCase):
         view = view or self.folder.restrictedTraverse('@@plone')
         manager = manager or getUtility(IPortletManager, name='plone.rightcolumn', context=self.portal)
         assignment = assignment or static.Assignment(header=u"title", text="text")
-        r = getMultiAdapter((context, request, view, manager, assignment), IPortletRenderer)
-        r.__portlet_metadata__ = {'key': '/'.join(self.portal.getPhysicalPath())}
-        return r
+        return getMultiAdapter((context, request, view, manager, assignment), IPortletRenderer)
 
     def test_render(self):
         r = self.renderer(context=self.portal, assignment=static.Assignment(header=u"title", text="<b>text</b>"))
@@ -96,11 +94,12 @@ class TestRenderer(TestCase):
         r = self.renderer(context=self.portal,
                           assignment=static.Assignment(header=u"Welcome text", text="<b>text</b>"))
         self.assertEquals('portlet-static-welcome-text', r.css_class())
-    
+
     def test_relative_link(self):
         folder_id = self.portal.invokeFactory('Folder', id='folder1', title='My Folder Title')
         r = self.renderer(context=self.portal[folder_id], assignment=static.Assignment(text="""<a href="relative/link">link</a>"""))
         r = r.__of__(self.folder)
+        r.__portlet_metadata__ = dict(category='context', key='/'.join(self.portal.getPhysicalPath()))
         r.update()
         output = r.render()
         self.assertTrue("http://nohost/plone/relative/link" in output)


### PR DESCRIPTION
and compute 'assignment context' only for 'context' portlet.