### PR TITLE
plone.app.widgets compatibility for Plone 4.3

### DIFF
--- a/plone/portlet/static/formhelper.py
+++ b/plone/portlet/static/formhelper.py
@@ -1,0 +1,201 @@
+from z3c.form import button
+from z3c.form import form
+from zope.component import getMultiAdapter
+from zope.interface import implements
+import zope.event
+import zope.lifecycleevent
+
+from Products.Five.browser import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+from Acquisition import aq_parent, aq_inner, aq_base
+from Acquisition.interfaces import IAcquirer
+
+from plone.app.portlets import PloneMessageFactory as _
+from plone.app.portlets.browser.interfaces import IPortletAddForm
+from plone.app.portlets.browser.interfaces import IPortletEditForm
+from plone.app.portlets.interfaces import IPortletPermissionChecker
+from plone.autoform.form import AutoExtensibleForm
+
+from Products.statusmessages.interfaces import IStatusMessage
+
+
+class AddForm(AutoExtensibleForm, form.AddForm):
+    """A base add form for portlets.
+
+    Use this for portlet assignments that require configuration before being
+    added. Assignment types that do not should use NullAddForm instead.
+
+    Sub-classes should define create() and set the form_fields class variable.
+
+    Notice the suble difference between AddForm and NullAddform in that the
+    create template method for AddForm takes as a parameter a dict 'data':
+
+        def create(self, data):
+            return MyAssignment(data.get('foo'))
+
+    whereas the NullAddForm has no data parameter:
+
+        def create(self):
+            return MyAssignment()
+    """
+
+    implements(IPortletAddForm)
+
+    template = ViewPageTemplateFile('z3cform-portlets-pageform.pt')
+
+    label = _(u"Configure portlet")
+
+    def add(self, object):
+        ob = self.context.add(object)
+        self._finishedAdd = True
+        return ob
+
+    def __call__(self):
+        self.request.set('disable_border', 1)
+        self.request.set('disable_plone.leftcolumn', 1)
+        self.request.set('disable_plone.rightcolumn', 1)
+        IPortletPermissionChecker(aq_parent(aq_inner(self.context)))()
+        return super(AddForm, self).__call__()
+
+    def createAndAdd(self, data):
+        obj = self.create(data)
+
+        # Acquisition wrap temporarily to satisfy things like vocabularies
+        # depending on tools
+        container = aq_inner(self.context)
+
+        if IAcquirer.providedBy(obj):
+            obj = obj.__of__(container)
+        form.applyChanges(self, obj, data)
+        obj = aq_base(obj)
+
+        zope.event.notify(zope.lifecycleevent.ObjectCreatedEvent(obj))
+        self.add(obj)
+        return obj
+
+    @property
+    def referer(self):
+        return self.request.get('referer', '')
+
+    def nextURL(self):
+        if self.referer:
+            return self.referer
+        addview = aq_parent(aq_inner(self.context))
+        context = aq_parent(aq_inner(addview))
+        url = str(getMultiAdapter((context, self.request),
+                                  name=u"absolute_url"))
+        return url + '/@@manage-portlets'
+
+    @button.buttonAndHandler(_(u"label_save", default=u"Save"), name='add')
+    def handleAdd(self, action):
+        data, errors = self.extractData()
+        if errors:
+            self.status = self.formErrorsMessage
+            return
+        obj = self.createAndAdd(data)
+        if obj is not None:
+            # mark only as finished if we get the new object
+            self._finishedAdd = True
+
+    @button.buttonAndHandler(_(u"label_cancel", default=u"Cancel"),
+                             name='cancel_add')
+    def handleCancel(self, action):
+        nextURL = self.nextURL()
+        if nextURL:
+            self.request.response.redirect(nextURL)
+        return ''
+
+
+class NullAddForm(BrowserView):
+    """An add view that will add its content immediately, without presenting
+    a form.
+
+    You should subclass this for portlets that do not require any configuration
+    before being added, and write a create() method that takes no parameters
+    and returns the appropriate assignment instance.
+    """
+
+    def __call__(self):
+        IPortletPermissionChecker(aq_parent(aq_inner(self.context)))()
+        ob = self.create()
+        zope.event.notify(zope.lifecycleevent.ObjectCreatedEvent(ob))
+        self.context.add(ob)
+        nextURL = self.nextURL()
+        if nextURL:
+            self.request.response.redirect(self.nextURL())
+        return ''
+
+    def nextURL(self):
+        referer = self.request.get('referer')
+        if referer:
+            return referer
+        else:
+            addview = aq_parent(aq_inner(self.context))
+            context = aq_parent(aq_inner(addview))
+            url = str(getMultiAdapter((context, self.request),
+                                      name=u"absolute_url"))
+            return url + '/@@manage-portlets'
+
+    def create(self):
+        raise NotImplementedError("concrete classes must implement create()")
+
+
+class EditForm(AutoExtensibleForm, form.EditForm):
+    """An edit form for portlets.
+    """
+
+    implements(IPortletEditForm)
+
+    template = ViewPageTemplateFile('z3cform-portlets-pageform.pt')
+
+    label = _(u"Modify portlet")
+
+    def __call__(self):
+        self.request.set('disable_border', 1)
+        self.request.set('disable_plone.leftcolumn', 1)
+        self.request.set('disable_plone.rightcolumn', 1)
+        IPortletPermissionChecker(aq_parent(aq_inner(self.context)))()
+        return super(EditForm, self).__call__()
+
+    @property
+    def referer(self):
+        return self.request.get('referer', '')
+
+    def nextURL(self):
+        if self.referer:
+            return self.referer
+        editview = aq_parent(aq_inner(self.context))
+        context = aq_parent(aq_inner(editview))
+        url = str(getMultiAdapter((context, self.request),
+                                  name=u"absolute_url"))
+        return url + '/@@manage-portlets'
+
+    @button.buttonAndHandler(_(u"label_save", default=u"Save"), name='apply')
+    def handleSave(self, action):
+        data, errors = self.extractData()
+        if errors:
+            self.status = self.formErrorsMessage
+            return
+        changes = self.applyChanges(data)
+        if changes:
+            self.status = "Changes saved"
+            IStatusMessage(self.request).addStatusMessage(_(u"Changes saved"),
+                                                          "info")
+        else:
+            self.status = "No changes"
+            IStatusMessage(self.request).addStatusMessage(_(u"No changes"),
+                                                          "info")
+
+        nextURL = self.nextURL()
+        if nextURL:
+            self.request.response.redirect(self.nextURL())
+        return ''
+
+    @button.buttonAndHandler(_(u"label_cancel", default=u"Cancel"),
+                             name='cancel_add')
+    def handleCancel(self, action):
+        nextURL = self.nextURL()
+        if nextURL:
+            self.request.response.redirect(nextURL)
+        return ''

--- a/plone/portlet/static/static.py
+++ b/plone/portlet/static/static.py
@@ -5,6 +5,8 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone.app.portlets.portlets import base
 from plone.app.textfield import RichText
 from plone.app.textfield.value import RichTextValue
+from plone.app.widgets.dx import RichTextFieldWidget
+from plone.autoform import directives
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.portlet.static import PloneMessageFactory as _
 from plone.portlets.interfaces import IPortletDataProvider
@@ -13,6 +15,9 @@ from zope.component import getUtility
 from zope.interface import implementer
 import logging
 import re
+
+from plone.portlet.static.formhelper import AddForm
+from plone.portlet.static.formhelper import EditForm
 
 logger = logging.getLogger('plone.portlet.static')
 
@@ -31,6 +36,7 @@ class IStaticPortlet(IPortletDataProvider):
         constraint=re.compile("[^\s]").match,
         required=False)
 
+    directives.widget(text=RichTextFieldWidget)
     text = RichText(
         title=_(u"Text"),
         description=_(u"The text to render"),
@@ -156,7 +162,7 @@ class Renderer(base.Renderer):
         return None
 
 
-class AddForm(base.AddForm):
+class AddForm(AddForm):
     """Portlet add form.
 
     This is registered in configure.zcml. The form_fields variable tells
@@ -174,7 +180,7 @@ class AddForm(base.AddForm):
         return Assignment(**data)
 
 
-class EditForm(base.EditForm):
+class EditForm(EditForm):
     """Portlet edit form.
 
     This is registered with configure.zcml. The form_fields variable tells

--- a/plone/portlet/static/z3cform-portlets-pageform.pt
+++ b/plone/portlet/static/z3cform-portlets-pageform.pt
@@ -1,0 +1,28 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="plone"
+      metal:use-macro="context/main_template/macros/master">
+
+<metal:block fill-slot="top_slot"
+                 tal:define="dummy python:request.set('disable_border',1);
+                             disable_column_one python:request.set('disable_plone.leftcolumn',1);
+                             disable_column_two python:request.set('disable_plone.rightcolumn',1);" />
+
+    <metal:block fill-slot="main">
+
+        <h1 class="documentFirstHeading" tal:content="view/label | nothing" />
+
+        <div id="content-core">
+            <metal:block use-macro="context/@@ploneform-macros/titlelessform" >
+                <metal:block fill-slot="formtop">
+                     <input type="hidden" name="referer" value="" tal:attributes="value view/referer" />
+                </metal:block>
+            </metal:block>
+        </div>
+
+
+    </metal:block>
+
+</html>

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-version = '3.0.1.1'
+version = '3.0.1.2'
 
 long_description = (
     read('README.rst')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-version = '3.0.2'
+version = '3.0.1.1'
 
 long_description = (
     read('README.rst')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-version = '3.0.1.2'
+version = '3.0.2'
 
 long_description = (
     read('README.rst')


### PR DESCRIPTION
This fixes the static text portlet on Plone 4.3 sites that have plone.app.widgets installed. Without this, the static text portlets do not have a visual editor. 

This pulls bits from the Plone 5 version of plone.app.portlets so the static text portlet can use plone.app.widget's rich text field. 

The only problem I have noticed with these changes is that the portlet assignments cannot be exported or imported via Generic Setup, it seems that would require some changes to plone.app.portlets. Not sure how important that is.