### PR TITLE
Fixed startup warning for setDefaultRoles.

### DIFF
--- a/news/17.bugfix
+++ b/news/17.bugfix
@@ -1,0 +1,2 @@
+Fixed startup warning for setDefaultRoles.
+[maurits]

--- a/plone/portlet/static/__init__.py
+++ b/plone/portlet/static/__init__.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
-from Products.CMFCore.permissions import setDefaultRoles
+from AccessControl.Permission import addPermission
 from zope.i18nmessageid import MessageFactory
+
 
 PloneMessageFactory = MessageFactory('plone')
 
-setDefaultRoles(
+addPermission(
     'plone.portlet.static: Add static portlet',
     ('Manager', 'Site Administrator', 'Owner', )
 )


### PR DESCRIPTION
```
DeprecationWarning: setDefaultRoles is deprecated. Please use addPermission from AccessControl.Permission.
```