### PR TITLE
Test-only fix: normalize white space.

### DIFF
--- a/news/49.bugfix
+++ b/news/49.bugfix
@@ -1,0 +1,2 @@
+Test-only fix: normalize white space.
+[maurits]

--- a/plone/portlet/static/tests/test_portlet_static.py
+++ b/plone/portlet/static/tests/test_portlet_static.py
@@ -15,6 +15,22 @@ from zope.component import getUtility, getMultiAdapter
 import unittest
 
 
+def normalize(value):
+    # Strip all white spaces of every line, then join on one line.
+    # But try to avoid getting 'Go to<a href' instead of 'Go to <a href'.
+    lines = []
+    for line in value.splitlines():
+        line = line.strip()
+        if (
+            line.startswith("<")
+            and not line.startswith("</")
+            and not line.startswith("<br")
+        ):
+            line = " " + line
+        lines.append(line)
+    return "".join(lines).strip()
+
+
 class TestPortlet(unittest.TestCase):
 
     layer = PLONEPORTLETSTATIC_INTEGRATION_TESTING
@@ -121,7 +137,7 @@ class TestRenderer(unittest.TestCase):
         r.update()
         output = r.render()
         self.assertTrue('title' in output)
-        self.assertTrue('<b>text</b>' in output)
+        self.assertTrue('<b>text</b>' in normalize(output))
 
     def test_no_header(self):
         r = self.renderer(


### PR DESCRIPTION
Needed to not fail with newer `plone.outputfilters` from this PR: https://github.com/plone/plone.outputfilters/pull/49
The tests then pass for both `plone.outputfilters` master and the PR branch.

See https://github.com/plone/plone.app.discussion/pull/202 for a similar fix, plus a bit more explanation.